### PR TITLE
data storage section + remove trailing periods in section numbers

### DIFF
--- a/pages/About/about.md
+++ b/pages/About/about.md
@@ -17,6 +17,7 @@ This site would not have been possible without help, feedback, and support from 
 * [Felicia Caponigri](https://twitter.com/fashionbyf), [Notre Dame Law School](https://law.nd.edu/)
 * [Nik Honeysett](https://twitter.com/nhoneysett) and the [Balboa Park Online Collaborative](https://www.bpoc.org/)
 * [Dan O'Flynn](https://twitter.com/danoflynn), [The British Museum](https://www.britishmuseum.org/)
+* [Tom Goskar](https://twitter.com/tomgoskar), [Curatorial Research Centre](https://www.curatorialresearch.com/) (primary original author of the [data storage](/digitize.html#63-data-storage) section)
 * Engelberg Center Student Fellow [Linnea Pittman](https://www.law.nyu.edu/centers/engelberg/team/pittman)
 * [Daniel Pett](https://twitter.com/DEJPett), [Fitzwilliam Museum](https://www.fitzmuseum.cam.ac.uk/)
 * [Al Rawlinson](https://twitter.com/alrawli), [Historic Environment Scotland](https://www.historicenvironment.scot/)
@@ -28,4 +29,4 @@ This site would not have been possible without help, feedback, and support from 
 
 The site content is licensed under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license.  The site itself is based on the [Jekyll Technical Documentation Theme](https://idratherbewriting.com/documentation-theme-jekyll/) by [Tom Johnson](https://idratherbewriting.com/aboutme/), modified by [Lauren Slowik](https://www.laurenslowik.com/).  It is licensed under an MIT license (except for the nav bar, which is licensed under a BSD license) and built with the Jekyll framework.  You can explore the site in the repository [here](https://github.com/NYUEngelberg/NYUEngelberg.github.io).
 
-Curious about how we plan to preserve this site for the future? We blogged about preservation plans [here](https://www.law.nyu.edu/centers/engelberg/news/2020-06-24-preserving-glam3d).  We also created a [Conifer Archive](https://conifer.rhizome.org/), which is available both on the [Conifer site](https://conifer.rhizome.org/EngelbergCenter/glam3dorg) and the [Internet Archive](https://archive.org/details/g3d_20201007). 
+Curious about how we plan to preserve this site for the future? We blogged about preservation plans [here](https://www.law.nyu.edu/centers/engelberg/news/2020-06-24-preserving-glam3d).  We also created a [Conifer Archive](https://conifer.rhizome.org/), which is available both on the [Conifer site](https://conifer.rhizome.org/EngelbergCenter/glam3dorg) and the [Internet Archive](https://archive.org/details/g3d_20201007).

--- a/pages/GLAM3D/appendix.md
+++ b/pages/GLAM3D/appendix.md
@@ -14,14 +14,14 @@ The following organizations are leading examples of 3D models and Open Access of
 
 
 
-##    i.i. The Cleveland Museum of Art (CMA)
+##    i.i The Cleveland Museum of Art (CMA)
 
 
 The Cleveland Museum of Art went Open Access in January 2020[^61] with the Open Access release of data and 2D images. CMA hosts an [online dashboard](https://www.clevelandart.org/art/collection/dashboard) that publicly reports engagement metrics on its open access program. Its policy also enables others to create their own 3D scans of public domain collections at the institution within certain conditions.[^62] CMA subsequently scanned and made available 3D images in partnership with Sketchfab on its platform and via the museum’s website using the Creative Commons Zero Public Domain Dedication for cultural resource items in the public domain.[^63] CMA was one of the first museums to make 3D models available on a museum website and use the Creative Commons Zero Public Domain Dedication. CMA plans to continue its 3D digitization efforts in years to come to present more interactive experiences for users and to innovate the production of cultural resources.
 
 
 
-##    i.ii. The National Gallery of Denmark (Statens Museum for Kunst; SMK)
+##    i.ii The National Gallery of Denmark (Statens Museum for Kunst; SMK)
 The National Gallery of Denmark (SMK) has been a pivotal leader in the international Open Access movement since 2016. Lead by Senior Advisor and Curator of Digital Museum Practice Merete Sanderhoff, with Head of Digital Jonas Heide Smith, the [SMK Open](https://www.smk.dk/en/article/smk-open/) program has produced important philosophical position statements through its blog, co-sponsored the “Sharing Is Caring” conference series[^64] that introduced innovative prototypes and new products, and continued to progress consistently with its ongoing rigorous commitment to Open Access. SMK has made significant contributions to the 3D imaging space as well, with its digital cast collection[^65] and partnerships with initiatives like Scan the World[^66] and MyMiniFactory.[^67] SMK partners with Sketchfab[^68] also to provide access to 3D images. 3D models of sculpture were also made available to explore on mobile devices in augmented reality.[^69]
 
 The ethos of SMK’s efforts with Open Access and its 3D images are defined by “radical openness” and it views cultural resource items as building blocks for making new culture:
@@ -43,7 +43,7 @@ SMK’s [project blog post](https://medium.com/smk-open/ghost-in-the-scan-3d-sca
 >He [Julius Lange, First Director of The Danish Royal Cast Collection] didn't contest that the originals also had their merits which he called sentimental value, the same as the relic had ahead of the cast, but that did not bear on the artistic value. Marble and bronze were beautiful materials, yet the plaster in full reproduced the plastic shape: “from where the work of art gets its spiritual meaning.”[^71]
 
 
-##    i.iii. The Smithsonian Institution
+##    i.iii The Smithsonian Institution
 
 The 3D Program team, within the Smithsonian Digitization Program Office, has built a corpus of 3D models of cultural resource items across the breadth and depth of the Smithsonian with examples from art, natural history, science and technology, and more.[^72] It has been working on developing a 3D model program since 2010,[^73] and in 2013 it hosted the notable _Smithsonian X 3D_ Conference.[^74] The Smithsonian 3D initiative has contributed to technological development with its open-source 3D viewer and authoring tool suite, Voyager.[^75] An especially important resource is Smithsonian 3D Metadata Model,[^76] which furthers the identification of essential data elements in an effort to support greater standardization and interoperability in the field. Regular publishing about the 3D initiative in _Smithsonian_ magazine, Digitization Program Office blog, and other media outlets have provided important updates to educators, enthusiasts, and peer practitioners at other cultural institutions.
 
@@ -55,7 +55,7 @@ On February 25, 2020, the Smithsonian took an important step to include 3D model
 
 ## ii. Anatomy of a 3D Model
 
-###    ii.i. Shape
+###    ii.i Shape
 
 A 3D model primarily differs from a 2D image by the addition of an extra dimension. Pixels in a digital 2D image exist on an X and Y axis (left and right, up and down), pixels in a 3D model can exist on these planes but also the Z axis, (forward and backward/closer and farther away from the viewer).
 
@@ -133,13 +133,13 @@ Deciding the output resolution for your 3D model should take into account the in
 
 
 
-####    ii.ii. Color
+####    ii.ii Color
 
 In addition to describing a shape or form in 3D, a mesh can have (among other things) color information attached to or embedded within it. There are a number of techniques that can be used to add color to a 3D model. They vary based on the original source of the color information, how the color information is attached to specific points on the shape, and how the integrity of the color changes as the model is scaled.
 
 
 
-#####        ii.ii.i. Vertex Color
+#####        ii.ii.i Vertex Color
 
 One way to color a 3D mesh is to assign a color value to each individual vertex. The color of any connected edge or face is then calculated on a gradient between the joined vertices. This is known as **vertex coloring**, and a mesh colored in this way is said to be **vertex colored**. The surface color of a vertex colored mesh is therefore directly linked to the fidelity of the mesh—if you reduce the resolution of the mesh, you reduce the resolution of the surface color information.
 
@@ -159,7 +159,7 @@ One way to color a 3D mesh is to assign a color value to each individual vertex.
 
 
 
-#####        ii.ii.ii. UV Texture Maps
+#####        ii.ii.ii UV Texture Maps
 
 In addition to coloring a 3D face using a blended gradient, it is possible to assign part of a 2D image file to fill the polygon or triangle surface. The method of assigning parts of an image to a 3D mesh surface is called **UV mapping**. This allows you to create the shape of the object in 3D and then apply a 2D image of the object to give it color and visual texture.
 
@@ -187,7 +187,7 @@ Vertex coloring and UV mapping are not mutually exclusive, and the same 3D mesh 
 
 
 
-#####        ii.ii.iii. Normal and Roughness Map—Specialized UV maps
+#####        ii.ii.iii Normal and Roughness Map—Specialized UV maps
 
 In addition to coloring the faces of a 3D mesh, there are several other texture maps[^87] that can have a dramatic effect on the presentation of a 3D model. Two baseline recommended map types are described below, but there are many more that can be created and applied to a 3D model to help more accurately render a given cultural resource.
 
@@ -195,7 +195,7 @@ In addition to coloring the faces of a 3D mesh, there are several other texture 
 
 
 
-######            ii.ii.iii.i. Normal Maps
+######            ii.ii.iii.i Normal Maps
 
 Each face of a 3D model has a surface direction, known as a _normal_. This direction dictates how simulated light bounces off the surface. If we have simplified or decimated a 3D model significantly during optimization, we can run into the problem that a single face replaces much more complex geometry.
 
@@ -247,7 +247,7 @@ While there are as many types of 3D files as there are applications for 3D, we w
 
 
 
-###    [iii.i. Mesh + UV Texture Maps](#mesh_uv_texture_maps)
+###    [iii.i Mesh + UV Texture Maps](#mesh_uv_texture_maps)
 
 Several 3D file formats support a 3D mesh in conjunction with a linked or embedded image map. Image files either need to be stored alongside the 3D mesh or are embedded in the 3D file itself.
 
@@ -265,7 +265,7 @@ Several 3D file formats support a 3D mesh in conjunction with a linked or embedd
 
 
 
-###    [iii.ii. Untextured Mesh](#untextured_mesh)
+###    [iii.ii Untextured Mesh](#untextured_mesh)
 
 A 3D mesh without any color data applied is said to be **untextured**. Untextured meshes are useful in situations in which the color information related to a cultural resource is not of use—for example, in certain methods of 3D printing or when the 3D form itself is what is important. Some 3D capture techniques like **X-ray computed tomography (CT scanning)** or some **structured light** scanning will not capture color data at the time of digitization.
 
@@ -282,7 +282,7 @@ A 3D mesh without any color data applied is said to be **untextured**. Untexture
 
 
 
-###    [iii.iii. Vertex Colored Mesh](#vertex_colored_mesh)
+###    [iii.iii Vertex Colored Mesh](#vertex_colored_mesh)
 
 The description of this coloring method is covered above, and it is a common output of some types of 3D scanning processes. Typically, any process that involves the capture or computation of colored vertices as part of 3D data production can lead to a vertex colored mesh output.
 
@@ -300,7 +300,7 @@ The description of this coloring method is covered above, and it is a common out
 
 
 
-###    [iii.iv. Point Cloud](#point_cloud)
+###    [iii.iv Point Cloud](#point_cloud)
 
 A point cloud or pointcloud is exactly what it sounds like: a 3D model made up exclusively of vertices (points). These kinds of files are commonly an output of LiDAR scanners (often referred to as _laser scanners_) or photogrammetry software. The vertices in a point cloud can be uncolored or have a color value assigned to them.
 
@@ -318,7 +318,7 @@ A point cloud or pointcloud is exactly what it sounds like: a 3D model made up e
 
 
 
-###    [iii.v. Volumetric Data](#volumetric_data)
+###    [iii.v Volumetric Data](#volumetric_data)
 
 Volumetric data is less common than surface model data in cultural heritage applications, and it is possible to generate a surface model from a volumetric input using specialized software.
 
@@ -335,9 +335,9 @@ The cross-sectional images can be used to generate **volumetric 3D data** —tha
 
 
 
-###    [iii.vi. Additional features](#additional_features)
+###    [iii.vi Additional features](#additional_features)
 
-####        [iii.vi.i. Animation](#animation)
+####        [iii.vi.i Animation](#animation)
 
 3D models can be animated in several ways. While animating models is beyond the scope of this paper, animation can help better describe how a cultural resource is constructed, functioned, or was used. Animation could also be the only way to record certain cultural performances, such as dance or theatre.
 
@@ -354,7 +354,7 @@ The cross-sectional images can be used to generate **volumetric 3D data** —tha
 
 
 
-####        [iii.vi.ii. 3D Post-Production—Materials and Lighting](#3d_post_production_Materials_and_lighting)
+####        [iii.vi.ii 3D Post-Production—Materials and Lighting](#3d_post_production_Materials_and_lighting)
 
 When we talk about “capturing a cultural resource in 3D,” we are most often referring to documenting the physical shape of the resource and possibly the surface color as well. Many cultural resources, however, are made from materials that possess specific physical properties that also contribute to a viewer’s understanding of the resource.
 
@@ -399,12 +399,12 @@ Just as in a museum environment, lighting can make a huge difference to how a cu
 
 ## [iv. Common 3D Capture and 3D Creation Techniques and Software](#3d_capturee_and_3d_creation_techniques_and_software)
 
-###    [iv.i. Capture](#capture)
+###    [iv.i Capture](#capture)
 **Capture** refers to the process of recording an existing cultural resource via digitization process.
 
 
 
-####        [iv.i.i. Photogrammetry](#photogrammetry)
+####        [iv.i.i Photogrammetry](#photogrammetry)
 
 As photography is a method for converting 3D information into a 2D format, photogrammetry does the opposite, converting 2D information back into digital 3D.
 
@@ -455,7 +455,7 @@ Difficult to capture subjects that are very shiny, transparent, extremely fine (
 
 
 
-####        [iv.i.ii. Structured Light](#structured_light)
+####        [iv.i.ii Structured Light](#structured_light)
 
 Structured light 3D scanners use specially calibrated projectors and cameras simultaneously projecting and recording a known pattern of lines or grids onto the subject being scanned. Dedicated software then defines a 3D surface model, based upon the distortions in the recorded line or grid pattern made by the subject.
 
@@ -495,7 +495,7 @@ Attempting to scan very large objects generally results in the creation of unusa
 
 
 
-####        [iv.i.iii. LiDAR / Laser Scanning](#lidar_laser_scanning)
+####        [iv.i.iii LiDAR / Laser Scanning](#lidar_laser_scanning)
 
 Laser scanning hardware is most often used in building information modeling (BIM) to record spaces and architectural scale features. Essentially, laser scanning works by firing a laser from a central unit and recording the 3D position of any surface it strikes, based upon how long the reflected light takes to return to the base station.
 
@@ -533,7 +533,7 @@ No surface or UV mapped color capture, generally not suitable for smaller object
 
 
 
-####        [iv.i.iv. X-ray Computed Tomography](#x-ray_computed_tomography)
+####        [iv.i.iv X-ray Computed Tomography](#x-ray_computed_tomography)
 
 Commonly used in medical and scientific fields.
 
@@ -571,7 +571,7 @@ No surface color information, scan size limited by x-ray machine volume/portabil
 
 
 
-####        [iv.i.v. Motion Capture](#motion_capture)
+####        [iv.i.v Motion Capture](#motion_capture)
 
 As the name suggests, motion capture is a digitization technique for capturing movement, most often that of human beings (e.g., full body, facial, hand motion). Traditionally this technique has required studio spaces with specialized cameras and tracking targets attached to the human performers. More recent developments in depth-sensing cameras and even smartphones are making motion capture a much more accessible technology.
 
@@ -611,7 +611,7 @@ No 3D model capture.
 
 
 
-###    [iv.ii. 3D Reconstruction and Creation](#3d_reconstruction_and_creation)
+###    [iv.ii 3D Reconstruction and Creation](#3d_reconstruction_and_creation)
 
 In addition to 3D scanning of a cultural resource, another way to generate 3D content is to engage a 3D artist to create it from scratch. This method is especially applicable to any cultural resource that is “unscannable,” no longer exists or was destroyed, or never existed in the first place—e.g., a fictional space or object.
 
@@ -621,7 +621,7 @@ Several sub-disciplines of creative work are applicable to generating 3D models 
 
 
 
-####        [iv.ii.i. Modeling](#modeling)
+####        [iv.ii.i Modeling](#modeling)
 
 3D modeling is the process of creating a three-dimensional representation of a surface or object by manipulating faces/polygons, edges, and vertices in simulated 3D space. Just as Adobe Photoshop and MS Paint are software programs used to create 2D art, 3D modeling software allows users to make art that can be explored in three dimensions.
 
@@ -653,7 +653,7 @@ Typical subjects for a modeling workflow include inorganic structures, architect
 
 
 
-####        [iv.ii.ii. Texture Painting](#texture_painting)
+####        [iv.ii.ii Texture Painting](#texture_painting)
 
 Once a 3D model has been created, an additional (sometimes essential) stage in production is to apply realistic colors and materials to the geometry. All texture maps (i.e., color, normal, roughness) can be digitally painted onto a 3D mesh, whether a 3D scan or something that has been created by a 3D artist.
 
@@ -685,7 +685,7 @@ Texture painting makes use of the UV mapping color method described previously a
 
 
 
-####        [iv.ii.iii. Sculpting](#sculpting)
+####        [iv.ii.iii Sculpting](#sculpting)
 
 As the name suggests, 3D sculpting is the process of manipulating a 3D object as if it was made out of a material similar to clay. You can push, pull, smooth, grab, pinch, and edit a 3D object to be whatever you’d like.
 
@@ -715,7 +715,7 @@ Typical subjects for a sculpting workflow include organic forms, animals, plants
 
 
 
-####        iv.ii.iv. Voxels
+####        iv.ii.iv Voxels
 
 A creation popularized by the videogame _Minecraft_, voxel-based 3D modeling uses visible 3D cubes or blocks (voxels) to build a 3D form. Voxel-based creations can be built “block by block” or existing meshes can be converted to a voxel form using a 3D editor. By no means useful for scientific study or hyper-realistic reconstructions, voxel-based 3D models can still be used to engage with wide-ranging audiences, especially younger crowds.[^93]
 
@@ -752,13 +752,13 @@ As a word of warning, be careful when using this “let’s just go ahead and ca
 You should also be aware that any time spent on a project will inevitably generate some form of technical and skill “debt”—i.e., commitment to processes and workflows based on the fact that they exist and are seen as the easiest option. This could make it difficult to change and adapt digitization workflows as required once proper planning is undertaken.
 
 
-###    [v.i. 3D Capture Workflow](#3d_capture_workflow)
+###    [v.i 3D Capture Workflow](#3d_capture_workflow)
 
 The cheapest and most accessible 3D capture workflow available to you is most likely photogrammetry. The input data are digital images and the required software runs on most computer hardware, with the caveat that on older and less powerful hardware, you will likely have to wait a lot longer for a 3D output to be processed. It is recognized that this suggested technology chain may still be unaffordable to some organizations.
 
 
 
-####        [v.i.i. Camera](#camera)
+####        [v.i.i Camera](#camera)
 
 Your personal digital camera or smartphone camera are likely good enough for a test project.
 
@@ -766,7 +766,7 @@ Tested.com hosts a good “[photography for photogrammetry” guide](https://www
 
 
 
-####        [v.i.ii. Software](#software)
+####        [v.i.ii Software](#software)
 
 Here’s a list of free photogrammetry software, with system requirements and official tutorials for each option. It is highly recommended that you review and consider the potential ongoing costs of using commercial software.
 
@@ -805,13 +805,13 @@ Here’s a list of free photogrammetry software, with system requirements and of
 *   [System Requirements](https://www.autodesk.co.uk/products/recap/free-trial#system-requirements)
 *   [Official Tutorials](https://knowledge.autodesk.com/support/recap/learn?sort=score)
 
-####        [v.i.iii. Computer Hardware](#computer_hardware)
+####        [v.i.iii Computer Hardware](#computer_hardware)
 
 Initially you can simply try running one or all of the suggested software applications on your existing computer hardware. If you find that installing the software does not work or processing takes too long or frequently fails, then it might be time to consider investing in something new, basing your purchase on the system requirements in the software section.
 
 
 
-####       [v.i.iv. Publishing](#publishing)
+####       [v.i.iv Publishing](#publishing)
 
 See the [Choosing an Online 3D Viewer](/disseminate.html#722-choosing-an-online-3d-viewer) section for hosted and self-hosted options.
 

--- a/pages/GLAM3D/digitize.md
+++ b/pages/GLAM3D/digitize.md
@@ -6,7 +6,7 @@ permalink: digitize.html
 
 ---
 
-##    6.1. 3D Scanning
+##    6.1 3D Scanning
 
 This section will provide you with best practices for 3D digitization. It will not suggest a single workflow because there is no universal workflow for capturing cultural resources in 3D. Most resources are unique in size, shape, material, handling guidelines, accessibility, and portability. Most GLAM organizations and digitization projects are unique in their staffing, funding, goals, and audiences.
 
@@ -16,7 +16,7 @@ Instead of searching for a single 3D digitization solution, it is more practical
 
 
 
-###        6.1.1. Do Your Research
+###        6.1.1 Do Your Research
 Spending time to research existing workflows, case studies, and advice will save you time in the long run. Read academic papers but also visit or subscribe to specialized blogs and forums, and follow experts and amateurs alike on social media. Piece together a knowledge base that is suitable to your goals before you begin and make a note of resources you feel will be valuable to revisit later. Don’t be afraid to reach out to colleagues, manufacturers, and software developers directly for specific advice—it can save you hours of searching and maybe even some money too.
 
 Below are a few online communities you may wish to consider joining, as well as a general reading list:
@@ -62,20 +62,20 @@ Below are a few online communities you may wish to consider joining, as well as 
 
 
 
-###        6.1.2. Capture the Best Result You Can And Work Transparently
+###        6.1.2 Capture the Best Result You Can And Work Transparently
 
 No matter how well resourced and organized, your 3D digitization project will likely be limited in some way. The equipment and time available to you will largely dictate the resolution and fidelity of your 3D output. Be transparent about those limitations to your users. Publishing lower-resolution and even incomplete 3D scans is fine as long as you also make it clear to audiences what it is they are viewing and how it was made.
 
-###   6.1.3. Document Your Process As Thoroughly As Possible
+###   6.1.3 Document Your Process As Thoroughly As Possible
 
 Following on from the previous point, and to re-assert the importance of meta- and paradata, record the details of your digitization and post-production process as much as possible. From the moment you begin your work, make note of the equipment you are using, decisions you are making, and the circumstances of the capture environment. Continue to document decisions made during processing and post-production and aim to publish this information at the same time as the 3D models.
 
-###   6.1.4. Plan For Mistakes And Technical Issues
+###   6.1.4 Plan For Mistakes And Technical Issues
 
 Things don’t always go according to plan, but you can prepare your workflow to cope with this. Give yourself more time than you need to conduct digitization. Plan extra and backup digitization sessions. If you are new to a 3D digitization process, budget time to make tests and get familiar with your tools. Unless your work is highly specialized, you will no doubt find an answer online to any unexpected roadblocks you experience.
 
 
-### 6.1.5. Archive Input Data And Project Files As Well As Output 3D Data
+### 6.1.5 Archive Input Data And Project Files As Well As Output 3D Data
 
 In an ideal world, all the data that is captured and produced during digitization would be available and archived in a way that accords with best practices. While this can quickly run to terabytes of data, making input data and project files available means other people can verify and build on your work. It will also allow you to go back to make additional uses of your scanning efforts as new technology develops. Long-term data storage and security should be considered during your project planning.
 
@@ -83,9 +83,9 @@ Cultural sector collections management, digital asset management, and digital pr
 
 
 
-##  6.2. Data Structures
+##  6.2 Data Structures
 
-###        6.2.1. Metadata and Paradata
+###        6.2.1 Metadata and Paradata
 
 Metadata related to 3D models of cultural resources includes information about the 3D file(s) and information regarding the cultural resource itself. The paradata explains how a 3D model was generated and details decisions that were made during this process. Meta- and paradata make a given 3D model more valuable and re-usable: If audiences better know what they are viewing or downloading, they are better able to understand it and incorporate it into their own plans.
 
@@ -113,7 +113,7 @@ What constitutes a complete metadata set and best practice for associating it wi
 
 Among the mature 3D digitization initiatives for cultural heritage, the [Smithsonian 3D Metadata Model](https://dpo.si.edu/blog/smithsonian-3d-metadata-model) offers one of the most complete attempts at defining a metadata scheme for cultural heritage 3D, based on extensive experience digitizing resources from multiple collections.
 
-###     6.2.2. Data Files
+###     6.2.2 Data Files
 
 The input and project files that you offer under Open Access will vary depending on your capture, processing, and post-production methods. The output and derivative 3D files will also vary depending on your project goals.
 
@@ -156,7 +156,7 @@ Two newer open 3D interchange formats that support embedded animations, color ma
 
 Duplicating or exporting a 3D model in multiple formats will of course take more time and significantly increase data storage requirements. This effect is compounded if 3D models at multiple resolutions for each file format are required. One approach to mitigate such issues might be to produce and maintain high-resolution “master” projects and 3D models files, only creating derivatives as and when they are required, it being even better if this process can be automated.
 
-###     6.2.3. Data Packages
+###     6.2.3 Data Packages
 
 By deliberately choosing a combination of 3D file formats, data resolutions, and linked meta- and paradata, it is possible to build “data packages” aimed at specific audiences. As part of digitization project planning, it is likely a good exercise to define target data packages and budgeting post-production resources to their preparation. If you are not sure of the best data package for your audience, it will behoove you to reach out to that audience before beginning digitization.
 
@@ -178,6 +178,107 @@ Three example data packages follow:
 
 *   Highly optimized derivative 3D data—e.g., GLTF, USDZ, low-resolution texture maps (1024x1024 pixels)
 *   Basic metadata
+
+## 6.3 Data Storage
+
+### 6.3.1 Data Size
+
+3D digitization can quickly create large numbers of files with an equally large storage requirement. A simple project can quickly exceed several gigabytes (GB), and a complex one can grow to terabytes (TB). Multiple smaller projects will also soon grow to require considerable total amounts of data storage.
+
+Data planning at the beginning of a project is essential to help protect the time spent digitizing in 3D, especially if repeat access to the physical cultural object is not possible. Caring for archived data after a project has finished is also essential.
+
+It can be difficult to accurately predict the amount of storage that you may require. A large photogrammetry project can quickly double or triple in size just through necessary steps such as saving multiple versions of a project through the stages of creating the 3D model, cleaning it, and creating various derivative files such as a high resolution uncleaned model, a high resolution cleaned version, and lower resolution files for distribution.
+
+### 6.3.2 External Drives for Capture and Work-in-Progress
+
+It is often a good idea to purchase or repurpose a new external hard drive for a photogrammetry project. Connected to a PC or Mac via USB3 these provide fast access to data and it is easy to keep an eye on how much storage a project is using.
+
+A 4 terabyte hard drive can be a good starting place with plenty of room for raw photographs and their derivatives, photogrammetry project files, and exported files. Aim for a USB-powered drive to avoid the need for an external power supply (which could develop a fault and be difficult to replace and therefore create difficulty in accessing the data in the future).   You should budget for two identical drives - one for the ‘live’ project and one for a running backup to protect your data if the primary drive fails.
+
+Always label a drive on the enclosure to allow easy identification. Labels can become detached through time, so make sure your labels are firmly attached to the drives (or write directly on the drives themselves).
+
+Once a project is complete you should ensure that the two drives, where possible (e.g. if full, and if budget allows) are stored safely.
+
+One drive may need to be on-hand for ongoing data access. The other drive should be stored carefully in a dry, low-magnetic environment. If you are in a museum, this could be in your institution’s archives where paper records are stored. You may wish to talk to relevant members of your team to ensure that the location is documented in an appropriate way.
+
+### 6.3.3 Directory Structure
+
+A clear, easily understood directory structure is essential to making use of your data. A complex 3D project can quickly create many files and become difficult to navigate. Always think about future access to the project and files by someone other than yourself. Will they be able to work out what files they need?
+
+An example structure for a photogrammetry project could be (directory names)
+
+- Project name
+    - Photographs
+        - RAW
+        - JPEG
+    - 3D
+        - Photogrammetry
+        - Exports
+            - High res uncleaned
+            - High res cleaned
+            - Low res cleaned
+            - Working
+    - Archive
+
+### 6.3.4 Files, Meta, and Paradata
+
+As computers become faster and photogrammetry methods improve, you may be able to re-process your raw data to produce better results in the future. IIt is good practice to ensure that you use ASCII formats where possible.  Even though these formats are not as easy to use for day-to-day processing, archiving your data in them will increase the likelihood that your files will be accessible when you need them. ASCII formats store 3D information and colors in plain text in the form of 3D coordinates (x,y,z,r,g,b).  A mesh or point cloud can be saved in the ASCII PLY format from most 3D software. Store this in your “Archive” directory.
+
+Use plain text (TXT) files to hold metadata describing the project directory structure and explain the contents, formats used, and paradata such as camera type, lens, and any notes about the conditions when the scan took place. Any other decisions about colour correction, sharpening, and other processing should be made here.
+
+There is no standard way of doing this, so be mindful that this should be easily understood in the future. Read the [GLAM 3D guidance for metadata and paradata](/digitize.html#621-metadata-and-paradata).
+
+### 6.3.5 Backup and Cloud Storage
+
+While USB external drives backups can be helpful, they can and do fail. If you do not have a backup, then you will have lost everything. This could be especially devastating if you cannot re-scan the subject because it has been destroyed, degraded, or lengthy travel was originally involved in accessing it.
+
+**Good: a second USB drive**
+
+A second USB drive is the easiest backup solution. Plenty of software is available that allows for drives to be backed up automatically or manually in a number of ways.
+
+This could be as simple as scheduling a time to regularly copy the contents of the drive to spare drive. It could be installing an app that does this for you. If backing up is a manual process, try to set reminders and keep a log of what was backed up and when.
+
+**Better: use the cloud**
+
+Cloud storage allows the creation of an off-site backup without requiring any other infrastructure. There are plenty of apps that allow external drives to be backed up to the cloud using, for example, [Amazon Glacier](https://aws.amazon.com/glacier/), [Dropbox](https://www.dropbox.com/), [Backblaze](https://www.backblaze.com/). Sometimes these apps are included with a USB drive.
+
+Cloud storage must be paid for (and continue to be paid for) so consider these costs when planning. A fast internet connection, particularly the upstream speed, will also be needed to complete an initial backup of large 3D datasets in a timely manner. How fast will depend on how long you can wait for a cloud transfer to take, but generally a minimum of 10Mbps upload speed will be needed.
+
+*If you stop paying for cloud storage - sometimes even accidentally - your backup will disappear. Consider using cloud storage in combination with two drives.*
+
+**Best: backup your drive to a server which has drive redundancy & cloud backup**
+
+Depending upon your resources you may be able to work with your organisation’s IT team to help you backup your project drive to a local server that you maintain, which can in turn be backed up in another way (e.g. [magnetic tape](https://en.wikipedia.org/wiki/Tape_drive), or to the cloud).
+
+Network Attached Storage (NAS) drives can be used as a local backup server. These small units are connected to networks where they appear as another drive, and often provide software for automatic backup processes. These devices can also be easier to administer than full servers.  Some NAS drives, such as those by Synology, have dedicated backup protocols built into the device, so that versions of files can be preserved if you need to roll-back an unwanted change or accidental deletion.
+
+NAS drives are often set up with redundant drives using a technology called [RAID](https://en.wikipedia.org/wiki/RAID). For example, a NAS drive with two HDD bays could be installed with two 4TB drives. It could be configured to provide 4TB storage, with 4TB of redundancy. All data saved to the 4TB drive would be instantly copied. If one of the drives were to fail, the data is safe on the other drive. While this protection against hard drive failure can be important, remember that RAID is in itself not a backup solution. Delete a file from one drive and it will be deleted on the other.
+
+If one drive fails then the faulty drive may be removed and a fresh one installed. The data would be automatically re-duplicated providing once again, two ‘live’ copies. Complex RAID configurations can be designed with multiple drive redundancy.
+
+NAS drives often contain cloud backup software so that off-site backups happen automatically.
+
+### 6.3.6 Confirm Backup Routines and Data Integrity
+
+As with all automatic methods, schedule time to check that these backups are actually occurring. This could be by manually checking your second drive or by examining the logs on your server/NAS drive.
+
+Always check the integrity of a backup by opening backed up files from time to time.
+
+### 6.3.7 Dissemination as a Form of Preservation
+
+In general, the more copies of a dataset, or parts of a dataset, that exist, the better. This means that one single location is not being relied upon for 3D assets to continue to be available.
+
+Consider making data available on multiple platforms. In addition to internal storage, make a copy available on your institution’s website.  Upload copies to other platforms as well.  The [Internet Archive](https://archive.org/) can store 3D files.  [Sketchfab](https://sketchfab.com/) will display them.  Data, metadata, and paradata about files can be stored on [GitHub](https://github.com).  Reduced - still high - quality models can be submitted to [Wikimedia Commons](https://commons.wikimedia.org/wiki/Main_Page).  None of these platforms is necessarily the best platform to store your data.  The key is to distribute it widely, thus decreasing the likelihood that a single failure will erase the data entirely.  
+
+### 6.3.8 Digital Archives
+
+Your country may have a dedicated digital archive service. For example, in the UK, the [Archaeology Data Service](https://archaeologydataservice.ac.uk) (ADS) can be contacted to discuss permanent backups of data related to archaeological projects in the country. Data lodged with the ADS is constantly monitored, moved to fresh disks, checked for integrity and so on, as part of an active data archive strategy. Data can also be made accessible through their web portal to enable Open Access.
+
+3D data can be costly to archive, so if archiving in this way is important to your project, have a conversation with a digital archivist right at the beginning of a project where possible.
+
+
+
+
 
 <br>
 <br>

--- a/pages/GLAM3D/disseminate.md
+++ b/pages/GLAM3D/disseminate.md
@@ -5,7 +5,7 @@ sidebar: glam3D_sidebar
 permalink: disseminate.html
 
 ---
-##    7.1. Review Goal-Setting
+##    7.1 Review Goal-Setting
 
 At this stage of a project, when the 3D models have been produced, documented, and archived locally, there is a natural break in activity, which presents an opportunity to review the goals that have been previously set for your project.
 
@@ -13,7 +13,7 @@ Digitization projects can take a long time to complete and new examples of disse
 
 
 
-##    7.2. Publish as Interactive 3D for Browsing Audiences
+##    7.2 Publish as Interactive 3D for Browsing Audiences
 
 As described in the “[What is a 3D Model?](what_is_a_3D_model.html)” section, for a user to truly experience a digital 3D model, the model needs to be interactive. At a very basic level, this means a user must be able to turn or tumble a 3D model to view the model from different angles and zoom in and out to get a closer look or broader overview of the resource. While this was previously only possible via dedicated applications running on specialized hardware, thanks to modern web standards like WebGL, it is possible to offer proper 3D interactive experiences in any modern browser. That means the model is accessible to all users, even those without the technical expertise to use their own 3D modeling software.
 
@@ -39,7 +39,7 @@ In this manner, it is possible to create interactive 3D tours of digitized cultu
 
 
 
-###        7.2.1. Notes on Digital Display
+###        7.2.1 Notes on Digital Display
 
 The same 3D model can generally be displayed using different 3D viewing software (often referred to as a _3D viewer_). 3D viewing software is different from 3D editing software (often referred to as a _3D editor_) in that the primary purpose or functionality is to simply display 3D data on screen as opposed to editing or converting it in any significant way.
 
@@ -64,13 +64,13 @@ Each software reads the 3D data file(s) and displays it as pixels on the screen�
 
 
 
-###        7.2.2. Choosing an Online 3D Viewer
+###        7.2.2 Choosing an Online 3D Viewer
 
 Deciding on which 3D viewer you use to display your 3D models online will largely depend on your project goals, your organization’s policies for using third-party platforms, and capacity for ongoing technical support and development.
 
 
 
-####            7.2.2.1. Self-Hosted Storage and Display Solutions
+####            7.2.2.1 Self-Hosted Storage and Display Solutions
 Self storage and hosting can offer greater control over how our 3D models are presented (e.g., custom interfaces) and how people interact with and access them (e.g., only via your organization’s website).[^58] These benefits come at the expense of maintaining web servers and application code.
 
 * [3DHOP](http://vcg.isti.cnr.it/3dhop/)
@@ -83,7 +83,7 @@ Self storage and hosting can offer greater control over how our 3D models are pr
 
 
 
-####            7.2.2.2. Hosted Storage and Display Solutions
+####            7.2.2.2 Hosted Storage and Display Solutions
 
 Using a hosted 3D viewer service is the quickest route to interactive online publication for your 3D data. Generally, using a hosted 3D viewer will require uploading your data to third-party-owned web servers and agreement to platform-specific terms of use. Benefits of using a hosted storage and display solution include reduced technical and staff overheads for you and your organization, and dissemination of your 3D models to an existing, 3D literate community.
 
@@ -97,7 +97,7 @@ Using a hosted 3D viewer service is the quickest route to interactive online pub
 
 
 
-##  7.3. Publish the 3D Data for Download
+##  7.3 Publish the 3D Data for Download
 
 Publishing a cultural resource as an interactive 3D model goes a long way to making 3D models findable and accessible. The next step is to make the 3D data available for download (hopefully alongside an interactive viewing experience). Published 3D data should be in an interoperable format—i.e., a 3D file that can be opened and edited in a piece of software. Publishing 3D data in an inaccessible format—for example, as a downloadable 3D PDF or self-contained app—is essentially a dead end for data re-use.
 
@@ -114,7 +114,7 @@ A managed approach in which an end user must, for example, request 3D data via e
 
 
 
-##    7.4. Publish Derivative Content
+##    7.4 Publish Derivative Content
 
 Publishing images, animations, and video derived from 3D models can be a helpful complement to the 3D data or viewer itself. Using media and media platforms that audiences are more familiar with can be an enticing gateway to engaging with the 3D data itself. Some examples:
 
@@ -145,18 +145,18 @@ Publishing images, animations, and video derived from 3D models can be a helpful
 
 
 
-##    7.5. Availability and Findability
+##    7.5 Availability and Findability
 
 Publishing the 3D data online in any form does not signify the end of an Open Access digitization project. An element of promotion and making the invitation to re-use 3D data clear to target audiences is essential to increase engagement with any Open Access program. Some select considerations for publishing your 3D outputs are laid out below. For guidelines to improve the findability, accessibility, interoperability, and re-use of any kind of digital assets, consider reviewing the [FAIR Principles](https://www.go-fair.org/fair-principles/).
 
 
 
-###        7.5.1. SEO
+###        7.5.1 SEO
 Good search engine optimization (SEO) of web pages featuring your 3D models will help people discover your project online. If somebody performs a web search for “[your organization name] Open Access” or “[term related to cultural resource] 3D model” (as two basic examples), they should be pointed in the right direction.
 
 
 
-###        7.5.2. Data Interfaces/APIs
+###        7.5.2 Data Interfaces/APIs
 Making your data available via both human and machine interfaces—that is to say browsable web pages as well as APIs—allows for different forms of engagement. The former caters to individuals and individuals presenting your work to a group (e.g., teachers presenting to a classroom of students); the latter can plug your cultural 3D data into entire digital platforms and get it in front of potentially massive 3D-oriented communities.
 
 ###### Browsing 3D models hosted on sketchfab.com in Facebook’s Spark AR application (used to make Instagram AR filters) is made possible by an [API integration](https://sparkar.facebook.com/ar-studio/learn/documentation/docs/ar-library/).
@@ -170,13 +170,13 @@ Making your data available via both human and machine interfaces—that is to sa
 
 [Google Poly API](https://developers.google.com/poly/develop/api)
 
-##    7.6. Active Promotion
+##    7.6 Active Promotion
 
 Once 3D data has been published, it should be a priority to advocate for its re-use by colleagues within your GLAM organization as much as by your target audiences. Teach people how 3D models can be embedded in object collection pages, exhibition marketing, in-gallery interactive—wherever it’s relevant. Make a special effort to support marketing and social media teams in understanding how they can draw on 3D model resources to create engaging content tailored for audiences where they already exist—i.e., digital newsletters, blog articles, and social media platforms.
 
 
 
-###        7.6.1. Partnerships
+###        7.6.1 Partnerships
 
 Any strategy for disseminating 3D content online should define basic partner platforms to help deliver the same 3D content in as many ways as possible. Different online platforms offer varying functionality and often cater to specific audiences and choosing the right platforms.
 
@@ -205,19 +205,19 @@ Some platforms to consider:
 *   [Wikimedia Commons](https://commons.wikimedia.org/) -
 “We’ve enabled a new feature that allows you to upload three-dimensional (3D) models.”
 
-##    7.7. Legal Infrastructure
+##    7.7 Legal Infrastructure
 
 It is critical to include legal information about digitized cultural assets to users. Without this information, users will be unable to make full use of digitized assets.
 
 
 
-###        7.7.1. Licensing Best Practices (Digitizations of Cultural Objects)
+###        7.7.1 Licensing Best Practices (Digitizations of Cultural Objects)
 
 As described in [Section 5.3](/identify.html#53-navigating-copyright-and-the-public-domain), many jurisdictions do not—or soon may not—recognize an additional copyright interest in digitizations. As a result, in many cases—although certainly not all—digitizing institutions will not have a copyright interest in the digital file that represents a cultural object. In light of this ambiguity, institutions should use licenses to clarify how users may make use of files included in Open Access initiatives.[^61]
 
 
 
-####            7.7.1.1. Legal Agreements
+####            7.7.1.1 Legal Agreements
 
 The current best practice is to use the [Creative Commons CC0 mark](https://creativecommons.org/share-your-work/public-domain/cc0/) on all Open Access digitized objects. The CC0 mark is designed to waive any copyright interest jurisdictions may grant your institution in the digitizations themselves. This includes the jurisdiction where your institution is based, as well as jurisdictions where your user may be based. Using the CC0 mark makes it clear to all users that the digitizing institution does not claim additional legal rights in a digitized object in the relatively unlikely event that those rights do exist.
 
@@ -231,7 +231,7 @@ Institutions should also avoid the impulse to impose additional restrictions on 
 
 
 
-####            7.7.1.2. Non-Legal Indicators
+####            7.7.1.2 Non-Legal Indicators
 
 While it is not best practice to impose legal restrictions on the use of digitized cultural resources, it is acceptable to make non-binding requests of those users. This is especially true in the case of restrictions—such as a requirement of attribution—that the institution is unlikely to actively enforce through legal mechanisms. It is critical that the institution makes it clear that it understands these requests to be non-binding, and not to cloak them in quasi-legal language or presentation styles.
 
@@ -241,7 +241,7 @@ These best practices have generally been developed for cultural resources in the
 
 
 
-###        7.7.2. Licensing Best Practices (Metadata and Descriptions)
+###        7.7.2 Licensing Best Practices (Metadata and Descriptions)
 
 [Section 5.3](/identify.html#53-navigating-copyright-and-the-public-domain) explains that digitizing institutions may have more legal rights in information such as metadata and descriptions of digitized cultural resources than digitized versions of the cultural resources themselves. Nonetheless, it is best practice for digitizing institutions to license all metadata and descriptions using the CC0 license.
 
@@ -250,14 +250,14 @@ Other permissive licensing structures (such as the attribution requirement of a 
 As with the digitized cultural resources themselves, nothing in the use of CC0 prevents the digitizing institution from requesting attribution or feedback on re-use. The difference between a request and a legally binding demand increases the amount of flexibility available to the user.
 
 
-###        7.7.3. Presenting Legal and Quasi-Legal Language
+###        7.7.3 Presenting Legal and Quasi-Legal Language
 
 Institutions should strive to present legal and legal-adjacent information in as approachable a manner as possible, and to streamline its presentation to the public. While licenses, warranties, and requests are important, they can also be intimidating to users without a background in legal text. The mere presence of “legalese” can act as a barrier for perfectly legitimate uses. Successful Open Access projects are inviting to users. While it may feel like adding one additional clause to address an edge case is responsible stewardship or lawyering, the cost of doing so may be reducing the types of engagement that motivate the initiative in the first place.
 
 In contrast to additional legal language, a clearly and concisely written values statement can help institutions articulate the role and position of an open access program in the holistic context of the organization. Value statements should be affirmative, considerate, and action-orientated, without taking a discouraging or scolding tone towards users.[^62]
 
 
-###        7.7.4. Cultural Labels and Notices
+###        7.7.4 Cultural Labels and Notices
 
 Many cultural resources have other considerations or cultural restrictions that are important to communicate to users. While these considerations and restrictions may not be legally binding, many users will benefit from being aware of them. Communities and stakeholders may also be more supportive of digitization and dissemination efforts when they are accompanied by this type of information.
 

--- a/pages/GLAM3D/identify.md
+++ b/pages/GLAM3D/identify.md
@@ -14,7 +14,7 @@ This section will help you find answers to some of those questions.
 
 
 
-##    5.1. Which Works Are Good Technical Matches with 3D Scanning?
+##    5.1 Which Works Are Good Technical Matches with 3D Scanning?
 
 Once a pool of cultural resources has been identified for digitization, the physical properties of those resources will largely dictate the method of digitization, or even disqualify them from digitization.
 
@@ -186,7 +186,7 @@ A summary table is provided for quick reference, with more detailed notes beneat
 
 
 
-###        [5.1.1. Insect Specimen](#insect_specimen)
+###        [5.1.1 Insect Specimen](#insect_specimen)
 **Significant Characteristics:**  
 Very small (less than 1 inch), highly detailed, fine and thin features, internal and external features, complex self-occluding forms.
 
@@ -230,7 +230,7 @@ Photogrammetry “focus stacking” workflow, x-ray CT.
 
 
 
-###        5.1.2. Coin
+###        5.1.2 Coin
 
 **Significant Characteristics:**
 Very small (less than 1 inch), highly detailed surface features, metallic, internal and external features.
@@ -269,7 +269,7 @@ Photogrammetry with polarized light + focus stacking workflow, structured light 
 
 
 
-###        5.1.3. Mammal Bone
+###        5.1.3 Mammal Bone
 
 **Significant Characteristics:**
 Very small (less than 1 inch) to medium size (a few feet), internal and external features, complex self-occluding forms.
@@ -309,7 +309,7 @@ Photogrammetry, structured light Scanning, x-ray CT.
 
 
 
-###        5.1.4. Engraved Metal Platter
+###        5.1.4 Engraved Metal Platter
 **Significant Characteristics:**
 
 Metallic/shiny, fine surface detail, thin.
@@ -348,7 +348,7 @@ Photogrammetry with polarized light, structured light scanning, r-ray CT.
 
 
 
-###     5.1.5. Glass Ornament
+###     5.1.5 Glass Ornament
 
 **Significant Characteristics:**
 
@@ -390,7 +390,7 @@ Photogrammetry with polarized light + dulling spray, structured light scanning, 
 
 
 
-###        5.1.6. Statue
+###        5.1.6 Statue
 
 **Significant Characteristics:**
 
@@ -432,7 +432,7 @@ Photogrammetry, structured light scanning (depending on subject size), x-ray CT 
 
 
 
-###   5.1.7. Building Interior and Exterior      
+###   5.1.7 Building Interior and Exterior      
 
 **Significant Characteristics:**
 
@@ -473,7 +473,7 @@ Photogrammetry, LiDAR.
 
 
 
-### 5.1.8. Performance
+### 5.1.8 Performance
 
 **Significant Characteristics:**
 
@@ -493,7 +493,7 @@ We do not currently have a good example of an Open Access representation of a pe
 
 
 
-## 5.2. Cultural and Other Non-Legal Considerations
+## 5.2 Cultural and Other Non-Legal Considerations
 
 There may also be non-legal factors to consider when selecting cultural resources to digitize and make available to the public.[^44] These factors may vary widely depending on the nature of your collection. One factor to consider is how you can effectively propagate an awareness of the cultural resource's original cultural context.
 
@@ -503,7 +503,7 @@ One innovative approach to cultural resources originating with indigenous commun
 
 
 
-##    5.3. Navigating Copyright and the Public Domain
+##    5.3 Navigating Copyright and the Public Domain
 
 Copyright status is another factor to consider when identifying cultural resources to make available to the public.[^46] Although copyright law varies from country to country, this section is intended to provide a working overview of the main concepts to consider.[^54] This should make it easier to coordinate with the legal department of your institution or outside legal experts to identify works unencumbered by copyright restrictions. In most cases, it will be easier to start working with items that are in the public domain, which means that their use is not restricted by copyright law.
 
@@ -515,7 +515,7 @@ Once the period of protection for a work has expired, it enters the public domai
 
 
 
-###        5.3.1. Copyright in Digitized Objects
+###        5.3.1 Copyright in Digitized Objects
 
 
 Digitizing an in-copyright work without permission will likely infringe on the rights of the copyright holder. In light of this, it may be wise to begin digitization with works that are already in the public domain.
@@ -524,7 +524,7 @@ For works already in the public domain, there have been questions as to whether 
 
 
 
-###        5.3.2. Copyright in Metadata
+###        5.3.2 Copyright in Metadata
 
 In addition to the digitized cultural artifact itself, many institutions will make para- and metadata about the object available to the public. This metadata may include straightforward technical information, such as the work’s dimensions, year of creation, or physical location in the institution itself. It may also include more nuanced information, such as prose written by a curator providing context and background information.
 
@@ -532,7 +532,7 @@ As a general matter, individual pieces of technically descriptive information—
 
 
 
-###        5.3.3. Other Legal Rights
+###        5.3.3 Other Legal Rights
 
 Although copyright is often the first legal consideration for Open Access digitization projects, the act of digitizing and releasing digital versions of objects in your collection can raise a number of other potential legal challenges. As noted earlier, objects may be encumbered by moral rights, cultural heritage laws, or other non-copyright-based restrictions on use. Your legal collaborators may be able to help you identify additional rules to be aware of when selecting works for digitization and dissemination.
 

--- a/pages/GLAM3D/introduction.md
+++ b/pages/GLAM3D/introduction.md
@@ -38,38 +38,38 @@ At that point, the publication begins to focus on the process itself. These sect
 The technology and practices related to Open Access 3D digital content creation and its release under Open Access principles are rapidly evolving. We hope to regularly update this resource in order to give you confidence that the information you are receiving is as relevant and timely as possible.
 
 
-###    1.3. How to Approach Your Open Access Program
+###    1.3 How to Approach Your Open Access Program
 
 Your Open Access program involves a number of steps. Each of the steps summarized below is explored more fully in its corresponding section.[^2]
 
 
 
-####        1.3.1. [Set Goals](/set_goals.html)
+####        1.3.1 [Set Goals](/set_goals.html)
 
 Identify the key objectives, routes to, and measure of success for your 3D digital content creation and publishing project. This includes identifying potential users and those users’ needs. Creating and distributing 3D digital content involves a number of choices and tradeoffs. Having concrete goals will help you evaluate your options and make decisions to match your intended outcomes. When setting goals, be sure to keep in mind the distinction between project outputs (e.g., “X number of 3D models published online”) and outcomes (e.g., “Increased engagement with our organization’s online collection records”).
 
 
 
-####        1.3.2. [Identify](/identify.html)
+####        1.3.2 [Identify](/identify.html)
 
 Select cultural resources for digital content creation that align with your project goals and assess their suitability for digital 3D creation methods based on technical, legal, and ethical grounds.
 
 
 
-####        1.3.3. [Digitize](/digitize.html)
+####        1.3.3 [Digitize](/digitize.html)
 
 Create digital content of the cultural resource in 3D through born digital or digitization methods, record metadata, paradata, structured data, and document the process openly.[^3]
 
 
 
-####        1.3.4. [Disseminate](/disseminate.html)
+####        1.3.4 [Disseminate](/disseminate.html)
 
 Deliver the output 3D files to your identified audience in the best way possible. This includes making the files viewable to users and making various versions of the files available to users, as well as associated para and metadata about the object, the files, and provenance for both.  
 
 
 
 
-####        1.3.5. [Evaluate](/evaluate_and_join.html)
+####        1.3.5 [Evaluate](/evaluate_and_join.html)
 
 Having established goals and implemented the Open Access program, it is time to reflect upon what worked, what did not, and what is left to do. Whenever possible, this evaluation should be shared publicly and with open licenses to the wider Open GLAM sector so that others can learn from your successes.
 

--- a/pages/GLAM3D/set_goals.md
+++ b/pages/GLAM3D/set_goals.md
@@ -10,7 +10,7 @@ As with most things, 3D digitization projects can benefit greatly from establish
 
 
 
-##    4.1. Target Audiences
+##    4.1 Target Audiences
 
 Deciding on the intended audience for your 3D content will help dictate the 3D capture or creation methods you will use, the 3D outputs you will produce, and how your 3D data will be made available. Identifying audiences (e.g., “schoolteachers”) and needs (e.g., “to illustrate and 3D print in relation to history curriculum subject ‘The Romans’”) will help you define both the cultural resources to be captured or created in 3D, as well as the most beneficial resolutions, file formats, display platforms, and dissemination methods for the resulting 3D data.
 
@@ -18,7 +18,7 @@ Identifying a primary audience establishes the need for 3D production; identifyi
 
 
 
-###       4.1.1. Scholarly
+###       4.1.1 Scholarly
 
 For in-depth investigations, the highest-fidelity 3D geometry and textures likely will be the most useful.[^37] It should be noted that achieving this grade of 3D data can require a greater financial investment in equipment and training, as well as staff and machine time required to compute 3D data and document workflows. At the same time, even lower-resolution files can still be useful in many scholarly contexts.
 
@@ -28,7 +28,7 @@ Some examples of 3D data made available primarily for scholarly use can be found
 
 
 
-###       4.1.2. Education
+###       4.1.2 Education
 
 Instead of forming the core of scholarly analysis, educational uses of 3D models rely on the models to facilitate the learning of a related subject. They can be used to illustrate a type of jewelry feature or allow students to explore a species of insect. This application differs from what we describe as “scholarly” uses in that the 3D models are not necessarily the focus of the educational experience or research. Instead, the 3D model is used to facilitate learning about a related subject.[^44]
 
@@ -45,7 +45,7 @@ Some examples of 3D models being used in the classroom are provided below:
 *   [3D Objects for Teachers](https://www.sciencemuseum.org.uk/objects-and-stories/3d-objects-teachers), Science Museum Group, [write-up](https://lab.sciencemuseum.org.uk/3d-object-scans-as-a-museum-learning-resource-part-1-9e1e51b67581), [context](https://lab.sciencemuseum.org.uk/science-museum-group-digital-lab-introduction-and-projects-1f7a6f26a208)
 *   [Samsung Discovery Centre @ British Museum](https://news.samsung.com/global/samsung-and-the-british-museum-offer-35000-school-pupils-the-chance-to-virtually-visit-the-museum)
 
-###        4.1.3. Public Engagement
+###        4.1.3 Public Engagement
 
 3D models increasingly make up part of a “complete” digital offering for GLAM institutions seeking to engage members of the public with cultural heritage and history. Alongside text, audio, and images, 3D offers yet another way to examine and experience historical themes and narratives.
 
@@ -64,7 +64,7 @@ Derivative 3D outputs like 3D prints and video are equally helpful for connectin
 
 
 
-###        4.1.4. Commercial
+###        4.1.4 Commercial
 
 Whether in-house at a cultural organization or at an external private company, there are many opportunities for 3D models to become part of a commercial endeavor. There is nothing about making cultural resources available on an Open Access basis that is inherently incompatible with offering physical and digital versions for sale as well.
 
@@ -74,7 +74,7 @@ Furthermore, all 3D data made available under an Open Access program remains ava
 
 
 
-##    4.2. Portion of Collection
+##    4.2 Portion of Collection
 
 At present, in most cases producing a 3D model of each cultural resource in cultural institution is not yet scalable in terms of cost, technology and workflow.
 
@@ -84,7 +84,7 @@ The defined number of cultural resources you wish to digitize should be achievab
 
 
 
-##    4.3. Budget
+##    4.3 Budget
 
 Your available budget has a direct impact on the quality of 3D models that you may produce. Consider the following expenses when planning your project:
 
@@ -103,7 +103,7 @@ Dissemination
 *   Service subscriptions
 *   Promotion
 
-##    4.4. Partners
+##    4.4 Partners
 
 Identify desired partnerships as part of the goal-setting process based on aspects of your project where you feel you need assistance or support. Partnerships can be valuable at all stages of a project: planning, digitization, post-production, and dissemination.
 

--- a/pages/GLAM3D/what_is_a_3d_model.md
+++ b/pages/GLAM3D/what_is_a_3d_model.md
@@ -6,7 +6,7 @@ permalink: what_is_a_3D_model.html
 
 ---
 
-##    3.1. Introduction to 3D Models
+##    3.1 Introduction to 3D Models
 
 In the simplest terms, a 3D model is just another kind of image: a way to show something to another person who is geographically or temporally removed from the original, physical cultural resource.
 
@@ -80,7 +80,7 @@ A more in-depth look at the anatomy of 3D files can be found in the [Anatomy of 
 
 
 
-###        3.1.1. Creating 3D Models
+###        3.1.1 Creating 3D Models
 
 This section includes some general guidance regarding commonly used 3D creation techniques. A more in-depth analysis of each technique can be found in the Appendix section [Common 3D Capture and 3D Creation Techniques and Software](/appendix.html#3d_capturee_and_3d_creation_techniques_and_software).
 
@@ -178,37 +178,37 @@ While this publication exists because the authors believe a considered approach 
 
 
 
-###     3.1.2. 3D Digitization Data Output Categories
+###     3.1.2 3D Digitization Data Output Categories
 
 The production of a single 3D model can entail a large number and variety of digital files, all of which may be offered under Open Access for specific audiences. A broad overview of digital file categories follows.
 
 
 
-####            3.1.2.1. Input Data
+####            3.1.2.1 Input Data
 
 Input data is the raw data captured at the initial digitization stage. For example, in a photogrammetry workflow, input data comprises digital images; in a laser scanning workflow, this would be the files output from the laser scanning hardware.
 
 
 
-####            3.1.2.2. Project Files
+####            3.1.2.2 Project Files
 
 Most 3D production workflows entail some processing or cleaning of raw data inputs. Edited data will most likely be stored in a proprietary format designed to be opened by a single, specific piece of software.
 
 
 
-####            3.1.2.3. Archival 3D Data
+####            3.1.2.3 Archival 3D Data
 
 Archival 3D data are the highest quality and fidelity output files from a given digitization scenario, intended to be accessible and readable in perpetuity. This data is likely of most use to expert audiences, including internal personnel responsible for collection management. Recommended archival 3D file formats for cultural heritage projects include X3D, U3D, PLY, DAE, OBJ, and STL.[^35]
 
 
 
-####            3.1.2.4. Derivative 3D Data
+####            3.1.2.4 Derivative 3D Data
 
 Derivative 3D data are 3D models derived from the archival 3D data, most likely simplified in some way and converted to other 3D file formats to facilitate quick and easy access and re-use as part of an Open Access offering for wider audiences.
 
 
 
-####            3.1.2.5. Metadata and Paradata
+####            3.1.2.5 Metadata and Paradata
 
 For all of the previous types of data, it is useful to provide additional context to what the 3D data is (metadata) and how it was captured or created and processed (paradata).
 

--- a/pages/GLAM3D/what_is_open_access.md
+++ b/pages/GLAM3D/what_is_open_access.md
@@ -18,19 +18,19 @@ The speed of digital content creation is fast and accelerating, and your organiz
 
 
 
-##    2.1. What Are You Providing Access To?
+##    2.1 What Are You Providing Access To?
 
 Your Open Access program provides access to various cultural resources. The nature of those resources depends on the defining characteristics, contexts, locations, and situations of your organization. Three categories of cultural resources, as conceived of and defined by the authors, are:
 
 
 
-###       2.1.1. Events
+###       2.1.1 Events
 
 An event is an activated occurrence accomplished by humans, nature, or generative artificial intelligence. While these events happen in a specific time and place, they can be documented in a wide variety of ways, from written accounts, to photographs, to conceptual frameworks (e.g., CIDOC-CRM), to 3D digital content.
 
 
 
-###       2.1.2. Environments        
+###       2.1.2 Environments        
 
 An environment is a place, setting, site, or structure made and affected by human, natural, or computationally generative activity.
 
@@ -42,7 +42,7 @@ An object is an intangible, such as a dance performed at a specific time and pla
 
 
 
-##    2.2. Consider Notions of Heritage with Cultural Resources
+##    2.2 Consider Notions of Heritage with Cultural Resources
 
 When preparing to implement digital content production and Open Access programs, it is important to consider notions of heritage with respect to cultural resources. Heritage is a concept that for some may elicit celebration or pride and reflect on a sense of tradition, while for others, heritage is linked to problematic practices such as entitled inheritance, hypernationalism, patrimony, and provincialism.
 
@@ -52,7 +52,7 @@ Discerning ethical positions on heritage and cultural resources is a consultativ
 
 
 
-##    2.3. Open Access Drives An Organization’s Mission and Empowers Its Vision
+##    2.3 Open Access Drives An Organization’s Mission and Empowers Its Vision
 
 Open Access is one of the most important priorities of any 21st-century cultural organization. Many institutions have priorities for public engagement and service as core elements of their missions. This commitment to service extends to both commercial and non-commercial entities related to an organization, including individuals, academics, and corporations, as well as nongovernmental and community organizations.
 
@@ -67,9 +67,9 @@ To put it directly and simply, Open Access is mission and vision critical for an
 
 
 
-##    2.4. What Does Open Access Achieve For A Cultural Organization?
+##    2.4 What Does Open Access Achieve For A Cultural Organization?
 
-###   2.4.1. Increased Engagement with Cultural Resources
+###   2.4.1 Increased Engagement with Cultural Resources
 
 Open Access increases engagement with cultural resources by closing the gap between discovery and re-use of resources by users, allowing users to sidestep burdensome, unnecessarily costly, and inefficient rights and permissions processes in order to engage with a cultural resource they discover.[^9] Open Access cultural resources propagate across sites and into communities, significantly increasing the likelihood that a member of the public will come into contact with them in the near term after launch,[^29] on an institution’s own hosted platform, or with the long-tail in partnership with organizations such as Creative Commons,[^10] Internet Archive, and Wikimedia.
 
@@ -77,7 +77,7 @@ For example, Wikimedia users have viewed works from The Metropolitan Museum of A
 
 
 
-###        2.4.2. Cost Savings and Reprioritization
+###        2.4.2 Cost Savings and Reprioritization
 
 A key incentive for cultural organizations to do Open Access is cost savings and reprioritization of staff time, labor, and tools. The cost of operating a rights and permissions program often exceeds associated revenue because of staff salaries, benefits, and inefficiencies in the process of administering policies and fulfilling requests.[^14] Licensing simply does not generate net revenue for most cultural resource stewards and creators, including cultural organizations.
 
@@ -87,7 +87,7 @@ Staff tasks and roles formerly dedicated to rights and permissions processes can
 
 
 
-###        2.4.3. New Creative and Economic Opportunities
+###        2.4.3 New Creative and Economic Opportunities
 
 Open Access can provide new creative and economic opportunities for organizations or independent content creators. Many cultural institutions also have businesses within them, such as brand, licensing, and trademark, as well as merchandising and retail. Cultural institutions operating businesses in an Open Access context need to think differently, take new approaches, and abandon highly controlling licensing agreements with limited terms.[^15] An Open Access marketplace is more competitive and free as makers have to inspire engagement and purchases through the quality of their product without the shield of restricted licensing frameworks. Innovative applications of digital content products, empowered by Open Access, can accelerate potential profits in the digital economy, especially in partnership with organizations and influencers that magnify the customer engagement with your brands.
 
@@ -103,7 +103,7 @@ Digital production tools for cultural resource makers are becoming more accessib
 
 
 
-###        2.4.4. Potential for Greater Authenticity Through Ubiquity
+###        2.4.4 Potential for Greater Authenticity Through Ubiquity
 
 Open Access cultural resources may have the potential for greater authenticity than closed cultural resources through the amplification of ideas and sources, along with critical interrogation.
 


### PR DESCRIPTION
Added what is now section 6.3 (Data Storage) in digitize.md file.  Also updated the about page to add Tom Goskar (primary original author of that section).  Also also removed the trailing periods in subsection numbers (for example '6.3.1.' becomes '6.3.1').  I have no idea what I was thinking with adding those in the first place.  Note that this trailing period change does not alter the first header in a section (so '6.' stays '6.').  